### PR TITLE
added paging API call support and example

### DIFF
--- a/duo_api_csharp.csproj
+++ b/duo_api_csharp.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -6,7 +6,7 @@
     <OutputType>Library</OutputType>
     <NoStandardLibraries>false</NoStandardLibraries>
     <AssemblyName>ClassLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/examples/DuoAdmin.cs
+++ b/examples/DuoAdmin.cs
@@ -39,6 +39,20 @@ class DuoAdmin
                 "\t" + "Username: " + (user["username"] as string));
         }
 
+        // paging call
+        int? offset = 0;
+        while (offset != null) {
+            var jsonResponse = client.JSONPagingApiCall("GET", "/admin/v1/users", parameters, 0, 10);
+            var pagedUsers = jsonResponse["response"] as System.Collections.ArrayList;
+            System.Console.WriteLine(String.Format("{0} users at offset {1}", pagedUsers.Count, offset));
+            foreach (Dictionary<string, object> user in pagedUsers) {
+                System.Console.WriteLine(
+                    "\t" + "Username: " + (user["username"] as string));
+            }
+            var metadata = jsonResponse["metadata"] as Dictionary<string, object>;
+            offset = metadata["next_offset"] as int?;
+        }
+
         return 0;
     }
 }

--- a/examples/DuoAdmin.cs
+++ b/examples/DuoAdmin.cs
@@ -42,7 +42,7 @@ class DuoAdmin
         // paging call
         int? offset = 0;
         while (offset != null) {
-            var jsonResponse = client.JSONPagingApiCall("GET", "/admin/v1/users", parameters, 0, 10);
+            var jsonResponse = client.JSONPagingApiCall("GET", "/admin/v1/users", parameters, offset, 10);
             var pagedUsers = jsonResponse["response"] as System.Collections.ArrayList;
             System.Console.WriteLine(String.Format("{0} users at offset {1}", pagedUsers.Count, offset));
             foreach (Dictionary<string, object> user in pagedUsers) {

--- a/test/ApiCallTest.cs
+++ b/test/ApiCallTest.cs
@@ -344,6 +344,18 @@ public class TestApiCall
     }
 
     [TestMethod]
+    public void TestValidJsonPagingResponse()
+    {
+        srv.handler = delegate (HttpListenerContext ctx)
+        {
+            return "{\"stat\": \"OK\", \"response\": \"hello, world!\", \"metadata\": {\"next_offset\":10}}";
+        };
+        var jsonResponse = api.JSONPagingApiCall("GET", "/json_ok", new Dictionary<string, string>(), 0, 10);
+        Assert.AreEqual(jsonResponse["response"], "hello, world!");
+        var metadata = jsonResponse["metadata"] as Dictionary<string, object>;
+        Assert.AreEqual(metadata["next_offset"], 10);
+    }
+    [TestMethod]
     public void TestErrorJsonResponse()
     {
         srv.handler = delegate(HttpListenerContext ctx)


### PR DESCRIPTION
Diff looks more complicated than it is.  Factors out the API call and "stat" checking, previous JSONApiCall calls the factored base function.  New JSONPagingApiCall functions also call the base function, returning a higher level result than the JSONApiCall functions.