### PR TITLE
Add automatic request retry/backoff when rate limited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 bin/
 obj/
 .vscode/
+.vs/


### PR DESCRIPTION
If the request is rate limited, this library will now sleep for
a bit and then try again. We use an exponential backoff, so the
request should sleep for 1 second, then 2, then 4, 8, 16, and max
out at 32 seconds.