### PR TITLE
add ci yml file + remove PostBuildEvent from DuoApiTest.csproj

### DIFF
--- a/.github/workflows/net-ci.yml
+++ b/.github/workflows/net-ci.yml
@@ -3,10 +3,10 @@ name: .NET CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   # Build and test on .NET Framework

--- a/.github/workflows/net-ci.yml
+++ b/.github/workflows/net-ci.yml
@@ -1,0 +1,29 @@
+name: .NET CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  # Build and test on .NET Framework
+  dotnet-framework-ci:
+    runs-on: windows-2022
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Set up VSTest
+        uses: darenm/Setup-VSTest@v1
+
+      - name: Build DuoApiTest solution
+        run: msbuild.exe test/DuoAPiTest.sln
+
+      - name: Run Tests dll
+        run: vstest.console.exe .\test\bin\Debug\test.dll

--- a/test/DuoApiTest.csproj
+++ b/test/DuoApiTest.csproj
@@ -47,9 +47,6 @@
     <Compile Include="SigningTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>nunit-console.exe "$(TargetPath)"</PostBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
This PR removes the `PostBuildEvent` from `test/DuoApiTest.csproj`. I did a manual test from VS Test Explorer. Tests still able to run locally.