### PR TITLE
Not convert Date when given date already in UTC DateTimeKind

### DIFF
--- a/duo_api_csharp/Duo.cs
+++ b/duo_api_csharp/Duo.cs
@@ -490,7 +490,12 @@ namespace Duo
             // between the offset's hours and minutes.
             string date_string = date.ToString(
                 "ddd, dd MMM yyyy HH:mm:ss", CultureInfo.InvariantCulture);
-            int offset = TimeZoneInfo.Local.GetUtcOffset(date).Hours;
+            int offset = 0;
+            // set offset if input date is not UTC time.
+            if (date.Kind != DateTimeKind.Utc)
+            {
+                offset = TimeZoneInfo.Local.GetUtcOffset(date).Hours;
+            }
             string zone;
             // + or -, then 0-pad, then offset, then more 0-padding.
             if (offset < 0)


### PR DESCRIPTION
DateTime was automatically convert to UTC time based on local timezone info. Only convert to UTC if data don't have UTC Kind