### PR TITLE
Hotfix: TLS 1.1/1.0 deprecation (June 30, 2023)

### DIFF
--- a/duo_api_csharp/Duo.cs
+++ b/duo_api_csharp/Duo.cs
@@ -38,6 +38,20 @@ namespace Duo
         private RandomService randomService;
         private bool sslCertValidation = true;
         private X509CertificateCollection customRoots = null;
+        
+        // TLS 1.0/1.1 deprecation effective June 30, 2023
+        // Of the SecurityProtocolType enum, it should be noted that SystemDefault is not available prior to .NET 4.7 and TLS 1.3 is not available prior to .NET 4.8.
+        private static SecurityProtocolType SelectSecurityProtocolType
+        {
+            get
+            {
+                SecurityProtocolType t;
+                if (!Enum.TryParse(ConfigurationManager.AppSettings["DuoAPI_SecurityProtocolType"], out t))
+                    return SecurityProtocolType.Tls12;
+
+                return t;
+            }
+        }
 
         /// <param name="ikey">Duo integration key</param>
         /// <param name="skey">Duo secret key</param>
@@ -273,6 +287,8 @@ namespace Duo
         private HttpWebRequest PrepareHttpRequest(String method, String url, String auth, String date,
             String cannonParams, int timeout)
         {
+            ServicePointManager.SecurityProtocol = SelectSecurityProtocolType;
+            
             HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
             request.ServerCertificateValidationCallback = GetCertificatePinner();
             request.Method = method;

--- a/duo_api_csharp/Duo.cs
+++ b/duo_api_csharp/Duo.cs
@@ -4,6 +4,7 @@
  */
 
 using System;
+using System.Configuration;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;

--- a/duo_api_csharp/duo_api_csharp.csproj
+++ b/duo_api_csharp/duo_api_csharp.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
## Description
Adds support for deployers to specify in application configuration which client TLS version to use when connecting to Duo API.

## Usage
Review the desired [`SecurityProtocolType` enum fields](https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype#fields) available in your .NET environment (version specific) and add a new **DuoAPI_SecurityProtocolType** entry to the`appSettings` section.

For example, under .NET 4.6 where the only usable enum of TLS 1.2 is supported (see note below), the following is provided as a working example:

```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <!-- ... -->

  <appSettings>
    <!-- ... -->

    <add key="DuoAPI_SecurityProtocolType" value="Tls12"/>
  </appSettings>
</configuration>
```

Note: `SystemDefault` does not exist before .NET 4.7 and `Tls13` does not exist before .NET 4.8. Therefore, TLS 1.2 is the default version hard-coded into this change as a backwards compatibility option for applications still running under .NET 4.6.

## Motivation and Context
This commit resolves TLS connection issues following deprecation of TLS 1.0/1.1 announced by duo to be effective June 30, 2023.

## How Has This Been Tested?
Changes were tested locally, verified against customer's Duo Admin interface, and tested/accepted for production release by customer UAT group.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
