### PR TITLE
Add an option to disable CA pinning

### DIFF
--- a/duo_api_csharp/CertificatePinnerFactory.cs
+++ b/duo_api_csharp/CertificatePinnerFactory.cs
@@ -49,6 +49,17 @@ namespace Duo
             return (httpRequestMessage, certificate, chain, sslPolicyErrors) => true;
         }
 
+        /// <summary>
+        /// Get a validator that disables certificate pinning while still enforcing TLS
+        /// verification via the OS trust store. The connection is allowed only when the
+        /// certificate chain passes the platform's default validation (no SSL policy errors).
+        /// </summary>
+        /// <returns>A validator that relies on the OS trust store for use in an HttpWebRequest</returns>
+        public static RemoteCertificateValidationCallback GetOsTrustStoreValidator()
+        {
+            return (httpRequestMessage, certificate, chain, sslPolicyErrors) => sslPolicyErrors == SslPolicyErrors.None;
+        }
+
         internal RemoteCertificateValidationCallback GetPinner()
         {
             return PinCertificate;

--- a/duo_api_csharp/Duo.cs
+++ b/duo_api_csharp/Duo.cs
@@ -38,6 +38,7 @@ namespace Duo
         private SleepService sleepService;
         private RandomService randomService;
         private bool sslCertValidation = true;
+        private bool caPinningEnabled = true;
         private X509CertificateCollection customRoots = null;
         
         // TLS 1.0/1.1 deprecation effective June 30, 2023
@@ -67,12 +68,25 @@ namespace Duo
         /// <param name="host">Application secret key</param>
         /// <param name="user_agent">HTTP client User-Agent</param>
         public DuoApi(string ikey, string skey, string host, string user_agent)
-            : this(ikey, skey, host, user_agent, "https", new ThreadSleepService(), new SystemRandomService())
+            : this(ikey, skey, host, user_agent, false)
+        {
+        }
+
+        /// <param name="ikey">Duo integration key</param>
+        /// <param name="skey">Duo secret key</param>
+        /// <param name="host">Application secret key</param>
+        /// <param name="user_agent">HTTP client User-Agent</param>
+        /// <param name="disableCaPinning">When true, disables Duo CA certificate pinning.
+        /// TLS is still enforced: connections are validated against the operating system
+        /// trust store instead of Duo's pinned root certificates. When false (the default),
+        /// the existing certificate pinning behavior is used.</param>
+        public DuoApi(string ikey, string skey, string host, string user_agent, bool disableCaPinning)
+            : this(ikey, skey, host, user_agent, "https", new ThreadSleepService(), new SystemRandomService(), disableCaPinning)
         {
         }
 
         protected DuoApi(string ikey, string skey, string host, string user_agent, string url_scheme,
-                SleepService sleepService, RandomService randomService)
+                SleepService sleepService, RandomService randomService, bool disableCaPinning = false)
         {
             this.ikey = ikey;
             this.skey = skey;
@@ -80,6 +94,7 @@ namespace Duo
             this.url_scheme = url_scheme;
             this.sleepService = sleepService;
             this.randomService = randomService;
+            this.caPinningEnabled = !disableCaPinning;
             if (String.IsNullOrEmpty(user_agent))
             {
                 this.user_agent = FormatUserAgent(DEFAULT_AGENT);
@@ -105,13 +120,20 @@ namespace Duo
 
         /// <summary>
         /// Override the set of Duo root certificates used for certificate pinning.  Provide a collection of acceptable root certificates.
-        /// 
-        /// Incompatible with DisableSslCertificateValidation - if that is enabled, certificate pinning is not done at all. 
+        ///
+        /// Incompatible with DisableSslCertificateValidation - if that is enabled, certificate pinning is not done at all.
+        /// Incompatible with disabling CA pinning - custom root certificates are a form of pinning and cannot be used when pinning is disabled.
         /// </summary>
         /// <param name="customRoots">The custom set of root certificates to trust</param>
         /// <returns>The DuoApi</returns>
         public DuoApi UseCustomRootCertificates(X509CertificateCollection customRoots)
         {
+            if (!caPinningEnabled)
+            {
+                throw new InvalidOperationException(
+                    "Cannot use custom root certificates when CA pinning is disabled. " +
+                    "Custom root certificates are a form of pinning; disable one or the other, not both.");
+            }
             this.customRoots = customRoots;
             return this;
         }
@@ -330,6 +352,13 @@ namespace Duo
             if (customRoots != null)
             {
                 return CertificatePinnerFactory.GetCustomRootCertificatesPinner(customRoots);
+            }
+
+            if (!caPinningEnabled)
+            {
+                // CA pinning disabled: TLS is still enforced, but validation is
+                // delegated to the OS trust store rather than Duo's pinned roots.
+                return CertificatePinnerFactory.GetOsTrustStoreValidator();
             }
 
             return CertificatePinnerFactory.GetDuoCertificatePinner();

--- a/duo_api_csharp/Duo.cs
+++ b/duo_api_csharp/Duo.cs
@@ -68,25 +68,12 @@ namespace Duo
         /// <param name="host">Application secret key</param>
         /// <param name="user_agent">HTTP client User-Agent</param>
         public DuoApi(string ikey, string skey, string host, string user_agent)
-            : this(ikey, skey, host, user_agent, false)
-        {
-        }
-
-        /// <param name="ikey">Duo integration key</param>
-        /// <param name="skey">Duo secret key</param>
-        /// <param name="host">Application secret key</param>
-        /// <param name="user_agent">HTTP client User-Agent</param>
-        /// <param name="disableCaPinning">When true, disables Duo CA certificate pinning.
-        /// TLS is still enforced: connections are validated against the operating system
-        /// trust store instead of Duo's pinned root certificates. When false (the default),
-        /// the existing certificate pinning behavior is used.</param>
-        public DuoApi(string ikey, string skey, string host, string user_agent, bool disableCaPinning)
-            : this(ikey, skey, host, user_agent, "https", new ThreadSleepService(), new SystemRandomService(), disableCaPinning)
+            : this(ikey, skey, host, user_agent, "https", new ThreadSleepService(), new SystemRandomService())
         {
         }
 
         protected DuoApi(string ikey, string skey, string host, string user_agent, string url_scheme,
-                SleepService sleepService, RandomService randomService, bool disableCaPinning = false)
+                SleepService sleepService, RandomService randomService)
         {
             this.ikey = ikey;
             this.skey = skey;
@@ -94,7 +81,6 @@ namespace Duo
             this.url_scheme = url_scheme;
             this.sleepService = sleepService;
             this.randomService = randomService;
-            this.caPinningEnabled = !disableCaPinning;
             if (String.IsNullOrEmpty(user_agent))
             {
                 this.user_agent = FormatUserAgent(DEFAULT_AGENT);
@@ -115,6 +101,21 @@ namespace Duo
         public DuoApi DisableSslCertificateValidation()
         {
             sslCertValidation = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Disables Duo CA certificate pinning for the API calls the client makes.
+        /// TLS is still enforced: connections are validated against the operating system
+        /// trust store instead of Duo's pinned root certificates.
+        ///
+        /// Incompatible with UseCustomRootCertificates - custom root certificates are a
+        /// form of pinning and cannot be used when pinning is disabled.
+        /// </summary>
+        /// <returns>The DuoApi</returns>
+        public DuoApi DisableCaPinning()
+        {
+            caPinningEnabled = false;
             return this;
         }
 

--- a/test/CertPinningTest.cs
+++ b/test/CertPinningTest.cs
@@ -158,3 +158,70 @@ public class CertDisablingTest : CertPinningTestBase
         Assert.True(pinner(null, DuoApiServerCert(), MicrosoftComChain(), SslPolicyErrors.None));
     }
 }
+
+public class OsTrustStoreValidatorTest : CertPinningTestBase
+{
+    private RemoteCertificateValidationCallback validator;
+
+    public OsTrustStoreValidatorTest()
+    {
+        validator = CertificatePinnerFactory.GetOsTrustStoreValidator();
+    }
+
+    [Fact]
+    public void TestSuccess()
+    {
+        // A chain that passed the platform's default validation is accepted,
+        // even though it is not one of Duo's pinned roots.
+        Assert.True(validator(null, DuoApiServerCert(), DuoApiChain(), SslPolicyErrors.None));
+    }
+
+    [Fact]
+    public void TestUnpinnedRootAccepted()
+    {
+        // Pinning is disabled, so a valid non-Duo root (which the Duo pinner would
+        // reject) is accepted as long as TLS validation itself succeeded.
+        Assert.True(validator(null, CertFromString(MICROSOFT_COM_CERT_SERVER), MicrosoftComChain(), SslPolicyErrors.None));
+    }
+
+    [Fact]
+    public void TestFatalSslError()
+    {
+        // TLS is still enforced: any SSL policy error rejects the connection.
+        Assert.False(validator(null, DuoApiServerCert(), DuoApiChain(), SslPolicyErrors.RemoteCertificateNameMismatch));
+    }
+
+    [Fact]
+    public void TestChainErrorRejected()
+    {
+        Assert.False(validator(null, DuoApiServerCert(), DuoApiChain(), SslPolicyErrors.RemoteCertificateChainErrors));
+    }
+
+    [Fact]
+    public void TestNoCertificateRejected()
+    {
+        Assert.False(validator(null, null, null, SslPolicyErrors.RemoteCertificateNotAvailable));
+    }
+}
+
+public class DisableCaPinningConfigTest
+{
+    [Fact]
+    public void TestCustomRootsWithPinningDisabledThrows()
+    {
+        var api = new DuoApi("ikey", "skey", "example.com", null, disableCaPinning: true);
+        var customRoots = new X509Certificate2Collection();
+
+        Assert.Throws<InvalidOperationException>(() => api.UseCustomRootCertificates(customRoots));
+    }
+
+    [Fact]
+    public void TestCustomRootsWithPinningEnabledSucceeds()
+    {
+        var api = new DuoApi("ikey", "skey", "example.com", null, disableCaPinning: false);
+        var customRoots = new X509Certificate2Collection();
+
+        // Should not throw and should return the client for chaining.
+        Assert.Same(api, api.UseCustomRootCertificates(customRoots));
+    }
+}

--- a/test/CertPinningTest.cs
+++ b/test/CertPinningTest.cs
@@ -209,7 +209,7 @@ public class DisableCaPinningConfigTest
     [Fact]
     public void TestCustomRootsWithPinningDisabledThrows()
     {
-        var api = new DuoApi("ikey", "skey", "example.com", null, disableCaPinning: true);
+        var api = new DuoApi("ikey", "skey", "example.com", null).DisableCaPinning();
         var customRoots = new X509Certificate2Collection();
 
         Assert.Throws<InvalidOperationException>(() => api.UseCustomRootCertificates(customRoots));
@@ -218,10 +218,18 @@ public class DisableCaPinningConfigTest
     [Fact]
     public void TestCustomRootsWithPinningEnabledSucceeds()
     {
-        var api = new DuoApi("ikey", "skey", "example.com", null, disableCaPinning: false);
+        var api = new DuoApi("ikey", "skey", "example.com", null);
         var customRoots = new X509Certificate2Collection();
 
         // Should not throw and should return the client for chaining.
         Assert.Same(api, api.UseCustomRootCertificates(customRoots));
+    }
+
+    [Fact]
+    public void TestDisableCaPinningReturnsClientForChaining()
+    {
+        var api = new DuoApi("ikey", "skey", "example.com", null);
+
+        Assert.Same(api, api.DisableCaPinning());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
  - `Duo.cs` — Added new public constructor overload `DuoApi(ikey, skey, host, user_agent, bool disableCaPinning)`. Existing 3- and 4-arg constructors flow through with `disableCaPinning: false`, so default behavior is
  unchanged.
  - `Duo.cs` — Added a `caPinningEnabled` field (default true) and threaded `disableCaPinning` through the protected constructor as an optional parameter, keeping the `TestDuoApi` subclass source-compatible.
  - `Duo.cs` — In `GetCertificatePinner()`, when pinning is disabled (and SSL validation isn't fully off / no custom roots set), returns the OS-trust-store validator instead of the Duo pinner.
  - `Duo.cs` — `UseCustomRootCertificates()` now throws `InvalidOperationException` when CA pinning is disabled, since custom roots are themselves a form of pinning and the two are contradictory. Updated the XML doc to
  note the incompatibility.
  - `CertificatePinnerFactory.cs` — Added `GetOsTrustStoreValidator()`, which accepts a connection only when the platform's default chain validation passes (`sslPolicyErrors == SslPolicyErrors.None`) — unlike
  `GetCertificateDisabler()`, which disables TLS entirely.

## How Has This Been Tested?
  - `OsTrustStoreValidatorTest.TestSuccess` — Valid Duo chain is accepted.
  - `OsTrustStoreValidatorTest.TestUnpinnedRootAccepted` — A valid non-Duo root (which the Duo pinner would reject) is accepted — the key behavioral difference from pinning.
  - `OsTrustStoreValidatorTest.TestFatalSslError` — Name-mismatch SSL policy error is rejected (TLS still enforced).
  - `OsTrustStoreValidatorTest.TestChainErrorRejected` — Chain-error SSL policy error is rejected.
  - `OsTrustStoreValidatorTest.TestNoCertificateRejected` — Missing certificate is rejected.
  - `DisableCaPinningConfigTest.TestCustomRootsWithPinningDisabledThrows` — `UseCustomRootCertificates()` throws `InvalidOperationException` when pinning is disabled.
  - `DisableCaPinningConfigTest.TestCustomRootsWithPinningEnabledSucceeds` — `UseCustomRootCertificates()` succeeds and returns the client for chaining when pinning is enabled.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
