### PR TITLE
chore: update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/net-ci.yml
+++ b/.github/workflows/net-ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: windows-2022
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
@@ -40,10 +40,10 @@ jobs:
     runs-on: windows-2022
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
 
       - name: Set up VSTest
         uses: darenm/Setup-VSTest@v1


### PR DESCRIPTION
## Summary
Updates GitHub Actions to Node 24-compatible versions ahead of the runner change: GitHub Actions runners default to Node 24 on **2026-06-16** and remove Node 20 in **fall 2026**. JS actions on Node 12/16/20 are all affected.

Every JS-based action is bumped to its latest Node 24-capable release, **SHA-pinned** with a version comment.

## Not changed (no Node 24 release / composite / archived)
- `darenm/Setup-VSTest` — no Node 24 release exists
- `dtolnay/rust-toolchain` — composite action, unaffected
- `actions/create-release`, `actions/upload-release-asset` — archived; need a rewrite

Only present where applicable in this repo.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

*This PR was generated with AI assistance (Claude).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)