### PR TITLE
Add CA bundle version and pinning status to the user agent string

### DIFF
--- a/duo_api_csharp/Duo.cs
+++ b/duo_api_csharp/Duo.cs
@@ -25,6 +25,7 @@ namespace Duo
     public class DuoApi
     {
         public string DEFAULT_AGENT = "DuoAPICSharp/1.1.0";
+        public const string CA_BUNDLE_VERSION = "ca_bundle/1.0";
 
         private const int INITIAL_BACKOFF_MS = 1000;
         private const int MAX_BACKOFF_MS = 32000;
@@ -319,7 +320,7 @@ namespace Duo
             request.Accept = "application/json";
             request.Headers.Add("Authorization", auth);
             request.Headers.Add("X-Duo-Date", date);
-            request.UserAgent = this.user_agent;
+            request.UserAgent = AppendCaInfo(this.user_agent);
             // If no proxy, check for and use WinHTTP proxy as autoconfig won't pick this up when run from a service
             if (!HasProxyServer(request))
                 request.Proxy = GetWinhttpProxy();
@@ -568,6 +569,15 @@ namespace Duo
             return String.Format(
                  "{0} ({1}; .NET {2})", product_name, System.Environment.OSVersion,
                  System.Environment.Version);
+        }
+
+        /// Appends the CA bundle version and current CA pinning status to a
+        /// User-Agent string. Composed at request time so the pinning status
+        /// reflects the client's runtime state (e.g. after DisableCaPinning).
+        private string AppendCaInfo(string agent)
+        {
+            string caPinning = caPinningEnabled ? "(ca_pinning=enabled)" : "(ca_pinning=disabled)";
+            return String.Format("{0} {1} {2}", agent, CA_BUNDLE_VERSION, caPinning);
         }
 
         #region Private Methods

--- a/test/ApiCallTest.cs
+++ b/test/ApiCallTest.cs
@@ -195,6 +195,8 @@ public class TestApiCall
         string response = api.ApiCall("GET", "/DefaultUserAgent", new Dictionary<string, string>(), 10000, out code);
         Assert.Equal(HttpStatusCode.OK, code);
         Assert.StartsWith(api.DEFAULT_AGENT, response);
+        Assert.Contains(DuoApi.CA_BUNDLE_VERSION, response);
+        Assert.EndsWith("(ca_pinning=enabled)", response);
     }
 
     [Fact]
@@ -209,7 +211,23 @@ public class TestApiCall
         HttpStatusCode code;
         string response = api.ApiCall("GET", "/CustomUserAgent", new Dictionary<string, string>(), 10000, out code);
         Assert.Equal(HttpStatusCode.OK, code);
-        Assert.Equal("CustomUserAgent/1.0", response);
+        Assert.Equal("CustomUserAgent/1.0 " + DuoApi.CA_BUNDLE_VERSION + " (ca_pinning=enabled)", response);
+    }
+
+    [Fact]
+    public void TestUserAgentCaPinningDisabled()
+    {
+        api = new TestDuoApi(test_ikey, test_skey, test_host, "CustomUserAgent/1.0");
+        api.DisableCaPinning();
+        srv.handler = delegate (HttpListenerContext ctx)
+        {
+            return ctx.Request.UserAgent;
+        };
+
+        HttpStatusCode code;
+        string response = api.ApiCall("GET", "/CaPinningDisabled", new Dictionary<string, string>(), 10000, out code);
+        Assert.Equal(HttpStatusCode.OK, code);
+        Assert.Equal("CustomUserAgent/1.0 " + DuoApi.CA_BUNDLE_VERSION + " (ca_pinning=disabled)", response);
     }
 
     [Fact]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
  - Added a `CA_BUNDLE_VERSION` constant (`ca_bundle/1.0`) to `DuoApi`.
  - Added a private `AppendCaInfo(string agent)` helper that appends the CA bundle version and the current pinning status —`(ca_pinning=enabled)` or `(ca_pinning=disabled)` — to a User-Agent string.
  - Set the request's `UserAgent` via `AppendCaInfo(this.user_agent)` so the pinning status reflects runtime state (e.g. after `DisableCaPinning()`).

## How Has This Been Tested?
  - **`TestDefaultUserAgent`** (updated): asserts the CA bundle version is present and the string ends with `(ca_pinning=enabled)`.
  - **`TestCustomUserAgent`** (updated): asserts the full expected User-Agent including the CA bundle version and `(ca_pinning=enabled)`.
  - **`TestUserAgentCaPinningDisabled`** (new): calls `DisableCaPinning()` and asserts the User-Agent ends with `(ca_pinning=disabled)`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
